### PR TITLE
Fix syntax error in redact/unredact

### DIFF
--- a/bin/homeshick
+++ b/bin/homeshick
@@ -130,7 +130,7 @@ case $cmd in
 	help)  help $help_cmd ;;
 	*)
 		case $cmd in
-			redact | unredact) if supports_storage ; then declare - A secrets: fi ;;
+			redact | unredact) if supports_storage ; then declare -A secrets; fi ;;
 		esac
 
 		for param in "${params[@]}"; do

--- a/bin/homeshick
+++ b/bin/homeshick
@@ -155,7 +155,7 @@ case $cmd in
 		case $cmd in
 			clone)   install_cloned_castle ${params[*]} ; symlink_cloned_files ${params[*]}     ;;
 			refresh) update_updated_castle ${params[*]} ; pull_outdated $threshhold ${params[*]} 	;;
-			pull)   iupdate_updated_castle ${params[*]} ;  symlink_new_files ${params[*]} ;         ;;
+			pull)   update_updated_castle ${params[*]} ;  symlink_new_files ${params[*]} ;         ;;
 		esac
 		result=$?
 		if [[ $exit_status == 0 && $result != 0 ]]; then


### PR DESCRIPTION
There's a syntax error in bin/homeshick. This fixes it.